### PR TITLE
Fix overflow logic in Layout

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -183,8 +183,7 @@ export default function Layout({ children }) {
               borderRadius: "1rem",
               boxShadow: "0 8px 24px rgba(0,0,0,0.15)",
               maxHeight: "calc(100vh - 98px)",
-              overflowY: isSettingsPage ? "auto" : "hidden",
-              overflowY: isLibraryPage ? "auto" : "hidden",
+              overflowY: isSettingsPage || isLibraryPage ? "auto" : "hidden",
               backdropFilter: contentBlur
             }}
           >


### PR DESCRIPTION
## Summary
- fix overflowY logic so settings or library pages can scroll

## Testing
- `npm test --silent -- -w=0 --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d2dd8ad08326804791bcfa642bd2